### PR TITLE
Add simple crypto portfolio simulator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.pyc
+portfolio.json
+report.xlsx
+report.pdf

--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
-# app-desarrollo
+# Crypto Portfolio Simulator
+
+This project provides a simple command line tool to monitor cryptocurrency prices
+using the CoinGecko API and manage a simulated portfolio. It can display current
+prices, plot historical prices with matplotlib, store a local portfolio in a JSON
+file and export reports in Excel or PDF formats.
+
+## Requirements
+- Python 3
+- `requests`
+- `matplotlib`
+- `pandas`
+- `openpyxl`
+- `reportlab`
+
+Install dependencies with:
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+```
+python -m crypto_app price bitcoin ethereum
+python -m crypto_app history bitcoin --days 7
+python -m crypto_app add bitcoin 0.5
+python -m crypto_app portfolio
+python -m crypto_app export --excel --pdf
+```

--- a/crypto_app/__main__.py
+++ b/crypto_app/__main__.py
@@ -1,0 +1,4 @@
+from .main import main
+
+if __name__ == '__main__':
+    main()

--- a/crypto_app/api.py
+++ b/crypto_app/api.py
@@ -1,0 +1,28 @@
+import requests
+
+API_BASE = 'https://api.coingecko.com/api/v3'
+
+def get_price(crypto_id='bitcoin', vs_currency='usd'):
+    """Return current price for a single crypto_id in vs_currency."""
+    url = f"{API_BASE}/simple/price"
+    params = {'ids': crypto_id, 'vs_currencies': vs_currency}
+    try:
+        response = requests.get(url, params=params, timeout=10)
+        response.raise_for_status()
+        data = response.json()
+        return data[crypto_id][vs_currency]
+    except Exception as e:
+        print(f"Error fetching price: {e}")
+        return None
+
+def get_history(crypto_id='bitcoin', days=30, vs_currency='usd'):
+    """Return historical price data list of [timestamp, price]."""
+    url = f"{API_BASE}/coins/{crypto_id}/market_chart"
+    params = {'vs_currency': vs_currency, 'days': days}
+    try:
+        response = requests.get(url, params=params, timeout=10)
+        response.raise_for_status()
+        return response.json().get('prices', [])
+    except Exception as e:
+        print(f"Error fetching history: {e}")
+        return []

--- a/crypto_app/export.py
+++ b/crypto_app/export.py
@@ -1,0 +1,24 @@
+import pandas as pd
+from reportlab.lib.pagesizes import letter
+from reportlab.pdfgen import canvas
+
+
+def export_excel(data, path='report.xlsx'):
+    """Export portfolio data to Excel."""
+    df = pd.DataFrame(list(data.items()), columns=['Crypto', 'Amount'])
+    df.to_excel(path, index=False)
+    print(f'Exported Excel to {path}')
+
+
+def export_pdf(data, path='report.pdf'):
+    """Export portfolio data to PDF."""
+    c = canvas.Canvas(path, pagesize=letter)
+    width, height = letter
+    y = height - 40
+    c.drawString(40, y, 'Crypto Portfolio Report')
+    y -= 20
+    for crypto, amount in data.items():
+        c.drawString(40, y, f'{crypto}: {amount}')
+        y -= 15
+    c.save()
+    print(f'Exported PDF to {path}')

--- a/crypto_app/main.py
+++ b/crypto_app/main.py
@@ -1,0 +1,69 @@
+import argparse
+from .api import get_price, get_history
+from .portfolio import Portfolio
+from .plot import plot_history
+from .export import export_excel, export_pdf
+
+
+def show_prices(crypto_ids):
+    for cid in crypto_ids:
+        price = get_price(cid)
+        if price is not None:
+            print(f'{cid.upper()}: ${price}')
+
+
+def show_history(crypto_id, days):
+    history = get_history(crypto_id, days)
+    plot_history(history, crypto_id)
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Crypto portfolio simulator')
+    subparsers = parser.add_subparsers(dest='command')
+
+    price_p = subparsers.add_parser('price', help='Show current prices')
+    price_p.add_argument('ids', nargs='+', help='Crypto IDs e.g. bitcoin')
+
+    hist_p = subparsers.add_parser('history', help='Show price history')
+    hist_p.add_argument('id', help='Crypto ID')
+    hist_p.add_argument('--days', type=int, default=30, help='Days of history')
+
+    add_p = subparsers.add_parser('add', help='Add crypto to portfolio')
+    add_p.add_argument('id')
+    add_p.add_argument('amount', type=float)
+
+    remove_p = subparsers.add_parser('remove', help='Remove crypto from portfolio')
+    remove_p.add_argument('id')
+    remove_p.add_argument('amount', type=float)
+
+    portfolio_p = subparsers.add_parser('portfolio', help='Show portfolio holdings')
+
+    export_p = subparsers.add_parser('export', help='Export portfolio')
+    export_p.add_argument('--excel', action='store_true')
+    export_p.add_argument('--pdf', action='store_true')
+
+    args = parser.parse_args()
+    pf = Portfolio()
+
+    if args.command == 'price':
+        show_prices(args.ids)
+    elif args.command == 'history':
+        show_history(args.id, args.days)
+    elif args.command == 'add':
+        pf.add(args.id, args.amount)
+    elif args.command == 'remove':
+        pf.remove(args.id, args.amount)
+    elif args.command == 'portfolio':
+        for cid, amount in pf.holdings().items():
+            print(f'{cid}: {amount}')
+    elif args.command == 'export':
+        if args.excel:
+            export_excel(pf.holdings())
+        if args.pdf:
+            export_pdf(pf.holdings())
+    else:
+        parser.print_help()
+
+
+if __name__ == '__main__':
+    main()

--- a/crypto_app/plot.py
+++ b/crypto_app/plot.py
@@ -1,0 +1,16 @@
+import matplotlib.pyplot as plt
+
+def plot_history(history, crypto_id='bitcoin'):
+    """Plot price history returned from get_history."""
+    if not history:
+        print('No history data to plot')
+        return
+    timestamps, prices = zip(*history)
+    plt.figure(figsize=(8, 4))
+    plt.plot(timestamps, prices, label=crypto_id)
+    plt.xlabel('Timestamp')
+    plt.ylabel('Price (USD)')
+    plt.title(f'{crypto_id} price history')
+    plt.legend()
+    plt.tight_layout()
+    plt.show()

--- a/crypto_app/portfolio.py
+++ b/crypto_app/portfolio.py
@@ -1,0 +1,39 @@
+import json
+from pathlib import Path
+from typing import Dict
+
+DATA_FILE = Path('portfolio.json')
+
+class Portfolio:
+    def __init__(self, path: Path = DATA_FILE):
+        self.path = path
+        self.data: Dict[str, float] = {}
+        self.load()
+
+    def load(self):
+        if self.path.exists():
+            with open(self.path, 'r') as f:
+                try:
+                    self.data = json.load(f)
+                except json.JSONDecodeError:
+                    self.data = {}
+        else:
+            self.data = {}
+
+    def save(self):
+        with open(self.path, 'w') as f:
+            json.dump(self.data, f, indent=2)
+
+    def add(self, crypto_id: str, amount: float):
+        self.data[crypto_id] = self.data.get(crypto_id, 0) + amount
+        self.save()
+
+    def remove(self, crypto_id: str, amount: float):
+        if crypto_id in self.data:
+            self.data[crypto_id] -= amount
+            if self.data[crypto_id] <= 0:
+                del self.data[crypto_id]
+            self.save()
+
+    def holdings(self) -> Dict[str, float]:
+        return dict(self.data)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+requests
+matplotlib
+pandas
+openpyxl
+reportlab


### PR DESCRIPTION
## Summary
- implement CoinGecko API helpers
- add portfolio management with JSON storage
- implement CLI for managing portfolio and viewing prices
- add Excel and PDF export helpers
- document usage in README

## Testing
- `python -m crypto_app price bitcoin ethereum ada` *(fails: unable to connect to proxy)*
- `python -m crypto_app add bitcoin 1`
- `python -m crypto_app portfolio`
- `python -m crypto_app export --excel`
- `python -m crypto_app export --pdf`


------
https://chatgpt.com/codex/tasks/task_e_686deabf6b84832781d2caee306e7bf5