### PR TITLE
Add unit tests for exporters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.gradle/
+DevPlanner_v5/DevPlanner_v5/.gradle/
+DevPlanner_v5/DevPlanner_v5/build/

--- a/DevPlanner_v5/DevPlanner_v5/app/build.gradle.kts
+++ b/DevPlanner_v5/DevPlanner_v5/app/build.gradle.kts
@@ -41,6 +41,10 @@ android {
         jvmTarget = "17"
     }
 
+    testOptions {
+        unitTests.isIncludeAndroidResources = true
+    }
+
     packaging {
         resources {
             excludes += setOf(
@@ -86,6 +90,8 @@ dependencies {
 
     // Testing
     testImplementation("junit:junit:4.13.2")
+    testImplementation("org.robolectric:robolectric:4.11.1")
+    testImplementation("androidx.test:core:1.5.0")
     androidTestImplementation("androidx.test.ext:junit:1.2.1")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.6.1")
     androidTestImplementation("androidx.compose.ui:ui-test-junit4")

--- a/DevPlanner_v5/DevPlanner_v5/app/src/test/java/com/example/devplanner/util/CsvExporterTest.kt
+++ b/DevPlanner_v5/DevPlanner_v5/app/src/test/java/com/example/devplanner/util/CsvExporterTest.kt
@@ -1,0 +1,28 @@
+package com.example.devplanner.util
+
+import com.example.devplanner.data.local.entity.TaskEntity
+import com.example.devplanner.data.local.entity.TaskStatus
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+class CsvExporterTest {
+    @Test
+    fun exportTasksToCsv_writesExpectedContent() {
+        val tasks = listOf(
+            TaskEntity(id = 1, projectId = 1, assigneeId = null, title = "Task1", description = "Desc1", estimateHours = 5, spentHours = 2, startDate = null, dueDate = null, status = TaskStatus.TODO),
+            TaskEntity(id = 2, projectId = 1, assigneeId = null, title = "Task2", description = null, estimateHours = 3, spentHours = 0, startDate = null, dueDate = null, status = TaskStatus.DONE)
+        )
+
+        val tempFile = File.createTempFile("test", ".csv").apply { deleteOnExit() }
+
+        val result = CsvExporter.exportTasksToCsv(tasks, tempFile)
+
+        assertTrue(result)
+        val expected = "ID,Title,Description,Status,EstimateHours,SpentHours\n" +
+                tasks.joinToString("\n") { t -> "${t.id},${t.title},${t.description ?: ""},${t.status},${t.estimateHours},${t.spentHours}" }
+        val actual = tempFile.readText()
+        assertEquals(expected, actual)
+    }
+}

--- a/DevPlanner_v5/DevPlanner_v5/app/src/test/java/com/example/devplanner/util/PdfExporterTest.kt
+++ b/DevPlanner_v5/DevPlanner_v5/app/src/test/java/com/example/devplanner/util/PdfExporterTest.kt
@@ -1,0 +1,26 @@
+package com.example.devplanner.util
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.example.devplanner.data.local.entity.TaskEntity
+import com.example.devplanner.data.local.entity.TaskStatus
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+class PdfExporterTest {
+    @Test
+    fun exportTasksToPdf_createsNonEmptyFile() {
+        val context: Context = ApplicationProvider.getApplicationContext()
+        val tasks = listOf(
+            TaskEntity(id = 1, projectId = 1, assigneeId = null, title = "Task1", description = null, estimateHours = 1, spentHours = 0, startDate = null, dueDate = null, status = TaskStatus.TODO)
+        )
+        val tempFile = File.createTempFile("test", ".pdf").apply { deleteOnExit() }
+
+        val result = PdfExporter.exportTasksToPdf(context, tasks, tempFile)
+
+        assertTrue(result)
+        assertTrue(tempFile.exists())
+        assertTrue(tempFile.length() > 0)
+    }
+}


### PR DESCRIPTION
## Summary
- test CsvExporter writes CSV to a temp file
- test PdfExporter creates a non-empty PDF
- enable Robolectric and android resources for unit tests

## Testing
- `gradle -p DevPlanner_v5/DevPlanner_v5 test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883f754b6e88327a5a3c7f2e1c7ad04